### PR TITLE
Add blocking functions for all functions in `PreferenceExtensions.kt`

### DIFF
--- a/preference-manager/src/main/kotlin/com/patrykmichalik/preferencemanager/PreferenceExtensions.kt
+++ b/preference-manager/src/main/kotlin/com/patrykmichalik/preferencemanager/PreferenceExtensions.kt
@@ -38,6 +38,18 @@ fun <C, S> Preference<C, S>.firstBlocking() = runBlocking { first() }
 
 fun <C, S> Preference<C, S>.setBlocking(value: C) = runBlocking { set(value = value) }
 
+fun Preference<Boolean, Boolean>.toggleBlocking() = runBlocking { toggle() }
+
+fun Preference<Int, Int>.incrementBlocking(by: Int = 1) = runBlocking { increment(by = by) }
+
+fun Preference<Int, Int>.decrementBlocking(by: Int = 1) = runBlocking { decrement(by = by) }
+
+fun Preference<Float, Float>.incrementBlocking(by: Float = 1f) = runBlocking { increment(by = by) }
+
+fun Preference<Float, Float>.decrementBlocking(by: Float = 1f) = runBlocking { decrement(by = by) }
+
+fun Preference<String, String>.clearBlocking() = runBlocking { clear() }
+
 @Composable
 fun <C, S> Preference<C, S>.state(initial: C? = null) = get().collectAsState(initial = initial)
 


### PR DESCRIPTION
Adds blocking functions for all available suspending functions in PreferenceExtensions.kt

Although these can potentially be seldomly used, having the option to use them can be extremely useful in special scenarios.